### PR TITLE
New exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethly-api",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Library with API for eth.ly",
   "scripts": {
     "build": "gulp build",

--- a/src/eth/index.js
+++ b/src/eth/index.js
@@ -1,5 +1,7 @@
 // @flow
 
+export * from 'eth/Client'
+
 export type EthereumAddress = string;
 export type PrivateKey = string;
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import {
 } from 'model'
 
 import type {
+  EthereumClient,
   EthereumAddress,
   PrivateKey,
   TransactionDraft,
@@ -20,11 +21,10 @@ import type {
   TransactionReceipt,
 } from 'eth'
 
-import {
-  type EthereumClient,
-} from 'eth/Client'
+import * as eth from 'eth'
 
 export {
+  eth,
   Link,
   StoredLink,
 }


### PR DESCRIPTION
- Exports of API were reorganized
- Now all types and classes can be accessed via `import` command of es6